### PR TITLE
work-around for mqtt bug

### DIFF
--- a/livemqttchart.html
+++ b/livemqttchart.html
@@ -10,26 +10,19 @@
 /*
 by @bordignon on twitter
 Feb 2014
-
 Simple example of plotting live mqtt/websockets data using highcharts.
-
 public broker and topic you can use for testing.
-
 	var MQTTbroker = 'broker.mqttdashboard.com';
 	var MQTTport = 8000;
 	var MQTTsubTopic = 'dcsquare/cubes/#'; //works with wildcard # and + topics dynamically now
-
 */
-
 //settings BEGIN
-	var MQTTbroker = 'broker.mqttdashboard.com';
-	var MQTTport = 8000;
-	var MQTTsubTopic = 'dcsquare/cubes/#'; //works with wildcard # and + topics dynamically now
+	var MQTTbroker = 'test.mosca.io';
+	var MQTTport = 80;
+	var MQTTsubTopic = 'HouseMalan/+/temperature'; //works with wildcard # and + topics dynamically now
 //settings END
-
 	var chart; // global variuable for chart
 	var dataTopics = new Array();
-
 //mqtt broker 
 	var client = new Paho.MQTT.Client(MQTTbroker, MQTTport,
 				"myclientid_" + parseInt(Math.random() * 100, 10));
@@ -37,31 +30,39 @@ public broker and topic you can use for testing.
 	client.onConnectionLost = onConnectionLost;
 	//connect to broker is at the bottom of the init() function !!!!
 	
-
 //mqtt connecton options including the mqtt broker subscriptions
 	var options = {
 		timeout: 3,
 		onSuccess: function () {
 			console.log("mqtt connected");
 			// Connection succeeded; subscribe to our topics
-			client.subscribe(MQTTsubTopic, {qos: 1});
+			client.subscribe(MQTTsubTopic, {qos: 0});
 		},
 		onFailure: function (message) {
 			console.log("Connection failed, ERROR: " + message.errorMessage);
 			//window.setTimeout(location.reload(),20000); //wait 20seconds before trying to connect again.
 		}
 	};
+// eclipse error work-around: keep another set of options to reuse
+function clone(obj) {
+    if (null == obj || "object" != typeof obj) return obj;
+    var copy = obj.constructor();
+    for (var attr in obj) {
+        if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
+    }
+    return copy;
+}
 
+	var options2 = clone(options);
+	
 //can be used to reconnect on connection lost
 	function onConnectionLost(responseObject) {
 		console.log("connection lost: " + responseObject.errorMessage);
-		//window.setTimeout(location.reload(),20000); //wait 20seconds before trying to connect again.
+		window.setTimeout(function() {init(); },20000); //wait 20seconds before trying to connect again.
 	};
-
 //what is done when a message arrives from the broker
 	function onMessageArrived(message) {
 		console.log(message.destinationName, '',message.payloadString);
-
 		//check if it is a new topic, if not add it to the array
 		if (dataTopics.indexOf(message.destinationName) < 0){
 		    
@@ -74,7 +75,6 @@ public broker and topic you can use for testing.
 		            name: message.destinationName,
 		            data: []
 		            };
-
 			chart.addSeries(newseries); //add the series
 		    
 		    };
@@ -88,28 +88,22 @@ public broker and topic you can use for testing.
 			plot(plotMqtt, y);	//send it to the plot function
 		};
 	};
-
 //check if a real number	
 	function isNumber(n) {
 	  return !isNaN(parseFloat(n)) && isFinite(n);
 	};
-
 //function that is called once the document has loaded
 	function init() {
-
 		//i find i have to set this to false if i have trouble with timezones.
 		Highcharts.setOptions({
 			global: {
 				useUTC: false
 			}
 		});
-
-		// Connect to MQTT broker
+		// Connect to MQTT broker (eclipse error workaround.)
+		options = clone(options2);
 		client.connect(options);
-
 	};
-
-
 //this adds the plots to the chart	
     function plot(point, chartno) {
     	console.log(point);
@@ -119,9 +113,7 @@ public broker and topic you can use for testing.
 	                                             // longer than 20
 	        // add the point
 	        chart.series[chartno].addPoint(point, true, shift);  
-
 	};
-
 //settings for the chart
 	$(document).ready(function() {
 	    chart = new Highcharts.Chart({
@@ -151,7 +143,6 @@ public broker and topic you can use for testing.
 	        series: []
 	    });        
 	});
-
 </script>
 
 <script src="http://code.highcharts.com/stock/highstock.js"></script>


### PR DESCRIPTION
When a reconnect is tried it fails because the paho code adds invalid options to var 'options'

To correct this bug now a clone of the original is made and re-used when the client tries to reconnect.

see https://www.eclipse.org/forums/index.php/t/1069724/
